### PR TITLE
feat: complex docs (properties that are arrays or objects)

### DIFF
--- a/index.js
+++ b/index.js
@@ -106,11 +106,19 @@ export class DbApi {
    * @param {IndexedDocument<TDoc>} doc
    */
   writeDoc(doc) {
-    const flattenedDoc = {
-      ...this.#docDefaults,
-      ...doc,
-      links: JSON.stringify(doc.links),
-      forks: JSON.stringify(doc.forks),
+    /** @type {Record<string, string | number | null>} */
+    const flattenedDoc = {}
+    for (const { name, dflt_value } of this.#tableInfo) {
+      const value = /** @type {Record<string, any>} */ (doc)[name]
+      if (value === null || typeof value === 'undefined') {
+        flattenedDoc[name] = dflt_value
+      } else if (typeof value === 'boolean') {
+        flattenedDoc[name] = value ? 1 : 0
+      } else if (typeof value === 'object') {
+        flattenedDoc[name] = JSON.stringify(value)
+      } else {
+        flattenedDoc[name] = value
+      }
     }
     this.#writeDocSql.run(flattenedDoc)
 

--- a/index.js
+++ b/index.js
@@ -3,10 +3,10 @@ import assert from 'assert'
 
 /**
  * @typedef {object} IndexableDocument
- * @property {string} id
- * @property {string} version
+ * @property {string} docId
+ * @property {string} versionId
  * @property {string[]} links
- * @property {string | number} [timestamp]
+ * @property {string} updatedAt
  */
 
 /** @typedef {{ type: string, pk: 1 | 0, cid: number, notnull: 1 | 0, dflt_value: any, name: string }} ColumnInfo */
@@ -23,15 +23,16 @@ import assert from 'assert'
 
 /** @type {ColumnSchema} */
 const docSchema = {
-  id: { type: 'TEXT', pk: 1, notnull: 1 },
-  version: { type: 'TEXT', notnull: 1, pk: 0 },
+  docId: { type: 'TEXT', pk: 1, notnull: 1 },
+  versionId: { type: 'TEXT', notnull: 1, pk: 0 },
   links: { type: 'TEXT', notnull: 1, dflt_value: null, pk: 0 },
   forks: { type: 'TEXT', notnull: 1, dflt_value: null, pk: 0 },
+  updatedAt: { type: 'TEXT', notnull: 1, pk: 0 },
 }
 
 /** @type {ColumnSchema} */
 const backlinkSchema = {
-  version: { type: 'TEXT', pk: 1, notnull: 1 },
+  versionId: { type: 'TEXT', pk: 1, notnull: 1 },
 }
 
 /**
@@ -44,6 +45,7 @@ export class DbApi {
   #writeBacklinkSql
   #updateForksSql
   #docDefaults
+  #tableInfo
 
   /** @type {Map<string, Set<IndexCallback<TDoc>>>} */
   #listeners = new Map()
@@ -56,9 +58,9 @@ export class DbApi {
    */
   constructor(db, { docTableName, backlinkTableName }) {
     assertValidSchema(db, { docTableName, backlinkTableName })
-    const tableInfo = /** @type {ColumnInfo[]} */ (
+    const tableInfo = (this.#tableInfo = /** @type {ColumnInfo[]} */ (
       db.prepare(`PRAGMA table_info(${docTableName})`).all()
-    )
+    ))
     this.#docDefaults = tableInfo.reduce(
       (acc, { name, dflt_value, notnull }) => {
         if (!notnull) acc[name] = dflt_value
@@ -68,33 +70,33 @@ export class DbApi {
     )
     const docColumns = tableInfo.map(({ name }) => name)
     this.#getDocSql = db.prepare(
-      `SELECT *
+      `SELECT docId, versionId, links, forks, updatedAt
       FROM ${docTableName}
-      WHERE id = ?`
+      WHERE docId = ?`
     )
     this.#writeDocSql = db.prepare(
       `REPLACE INTO ${docTableName} (${docColumns.join(',')})
       VALUES (${docColumns.map((name) => `@${name}`).join(',')})`
     )
     this.#updateForksSql = db.prepare(
-      `UPDATE ${docTableName} SET forks = @forks WHERE id = @id`
+      `UPDATE ${docTableName} SET forks = @forks WHERE docId = @docId`
     )
     this.#getBacklinkSql = db.prepare(
-      `SELECT version
+      `SELECT versionId
       FROM ${backlinkTableName}
-      WHERE version = ?`
+      WHERE versionId = ?`
     )
     this.#writeBacklinkSql = db.prepare(
-      `INSERT OR IGNORE INTO ${backlinkTableName} (version)
+      `INSERT OR IGNORE INTO ${backlinkTableName} (versionId)
       VALUES (?)`
     )
   }
   /**
-   * @param {string} id
-   * @returns {IndexedDocument<TDoc> | undefined}
+   * @param {string} docId
+   * @returns {IndexedDocument | undefined}
    */
-  getDoc(id) {
-    const doc = /** @type {any} */ (this.#getDocSql.get(id))
+  getDoc(docId) {
+    const doc = /** @type {any} */ (this.#getDocSql.get(docId))
     if (!doc) return
     doc.links = JSON.parse(doc.links)
     doc.forks = JSON.parse(doc.forks)
@@ -112,34 +114,34 @@ export class DbApi {
     }
     this.#writeDocSql.run(flattenedDoc)
 
-    const { version } = doc
-    if (this.#listeners.has(version)) {
+    const { versionId } = doc
+    if (this.#listeners.has(versionId)) {
       process.nextTick(() => {
-        const set = this.#listeners.get(version)
+        const set = this.#listeners.get(versionId)
         if (set) {
           for (const listener of set.values()) {
             listener(doc)
           }
-          this.#listeners.delete(version)
+          this.#listeners.delete(versionId)
         }
       })
     }
   }
   /**
-   * @param {string} version
+   * @param {string} versionId
    * @param {IndexCallback<TDoc>} listener
    */
-  onceWriteDoc(version, listener) {
-    if (!this.#listeners.has(version)) {
-      this.#listeners.set(version, new Set())
+  onceWriteDoc(versionId, listener) {
+    if (!this.#listeners.has(versionId)) {
+      this.#listeners.set(versionId, new Set())
     }
 
-    const set = this.#listeners.get(version)
+    const set = this.#listeners.get(versionId)
     if (set && set.has(listener)) {
       return
     } else if (set) {
       set.add(listener)
-      this.#listeners.set(version, set)
+      this.#listeners.set(versionId, set)
     }
   }
   /**
@@ -148,21 +150,21 @@ export class DbApi {
    */
   updateForks(docId, forks) {
     this.#updateForksSql.run({
-      id: docId,
+      docId: docId,
       forks: JSON.stringify(forks),
     })
   }
   /**
-   * @param {string} version
+   * @param {string} versionId
    */
-  getBacklink(version) {
-    return this.#getBacklinkSql.get(version)
+  getBacklink(versionId) {
+    return this.#getBacklinkSql.get(versionId)
   }
   /**
-   * @param {string} version
+   * @param {string} versionId
    */
-  writeBacklink(version) {
-    this.#writeBacklinkSql.run(version)
+  writeBacklink(versionId) {
+    this.#writeBacklinkSql.run(versionId)
   }
 }
 
@@ -195,8 +197,7 @@ export default class SqliteIndexer {
   /** @param {TDoc[]} docs */
   #batch(docs) {
     for (const doc of docs) {
-      /** @type {IndexedDocument<TDoc> | undefined} */
-      const existing = this.#dbApi.getDoc(doc.id)
+      const existing = this.#dbApi.getDoc(doc.docId)
       // console.log('existing', existing)
       // console.log('doc', doc)
       let forksDirty = false
@@ -210,17 +211,17 @@ export default class SqliteIndexer {
       }
 
       // If the doc is linked to by another doc, then it's not a head, so we can ignore it
-      if (this.isLinked(doc.version)) {
+      if (this.isLinked(doc.versionId)) {
         if (existing && forksDirty) {
           // console.log('updating forks', doc.id, existing.forks)
-          this.#dbApi.updateForks(doc.id, existing.forks)
+          this.#dbApi.updateForks(doc.docId, existing.forks)
         }
         continue
       }
 
       if (!existing) {
         this.#dbApi.writeDoc({ ...doc, forks: [] })
-      } else if (this.isLinked(existing.version)) {
+      } else if (this.isLinked(existing.versionId)) {
         // console.log('existing linked', existing.version)
         // The existing doc for this ID is now linked, so we can replace it
         this.#dbApi.writeDoc({ ...doc, forks: [] })
@@ -232,47 +233,42 @@ export default class SqliteIndexer {
         // TODO: Can the forks Set get out of date over time? E.g. could some of
         // the forks end up being linked by a doc that is indexed later on?
         if (winner === existing) {
-          existing.forks.push(doc.version)
-          this.#dbApi.updateForks(existing.id, existing.forks)
+          existing.forks.push(doc.versionId)
+          this.#dbApi.updateForks(existing.docId, existing.forks)
         } else {
-          existing.forks.push(existing.version)
+          existing.forks.push(existing.versionId)
           this.#dbApi.writeDoc({ ...doc, forks: existing.forks })
         }
       }
     }
   }
 
-  /** @param {string} version */
-  isLinked(version) {
-    return !!this.#dbApi.getBacklink(version)
+  /** @param {string} versionId */
+  isLinked(versionId) {
+    return !!this.#dbApi.getBacklink(versionId)
   }
 
   /**
-   * @param {string} version
+   * @param {string} versionId
    * @param {IndexCallback<TDoc>} listener
    */
-  onceWriteDoc(version, listener) {
-    this.#dbApi.onceWriteDoc(version, listener)
+  onceWriteDoc(versionId, listener) {
+    this.#dbApi.onceWriteDoc(versionId, listener)
   }
 }
 
 /**
- *
- * @param {IndexableDocument} docA
- * @param {IndexableDocument} docB
- * @returns IndexableDocument
+ * @template {IndexableDocument} T
+ * @template {IndexableDocument} U
+ * @param {T} docA
+ * @param {U} docB
+ * @returns T | U
  */
 function defaultGetWinner(docA, docB) {
-  if (
-    // Checking neither null nor undefined
-    docA.timestamp != null &&
-    docB.timestamp != null
-  ) {
-    if (docA.timestamp > docB.timestamp) return docA
-    if (docB.timestamp > docA.timestamp) return docB
-  }
+  if (docA.updatedAt > docB.updatedAt) return docA
+  if (docB.updatedAt > docA.updatedAt) return docB
   // They are equal or no timestamp property, so sort by version to ensure winner is deterministic
-  return docA.version > docB.version ? docA : docB
+  return docA.versionId > docB.versionId ? docA : docB
 }
 
 /**

--- a/test/complex-docs.js
+++ b/test/complex-docs.js
@@ -1,0 +1,74 @@
+// @ts-check
+import test from 'tape'
+import { create } from './utils.js'
+
+test('booleans, arrays and objects are transformed', async (t) => {
+  const updatedAt = new Date(1999, 0, 1).toISOString()
+  const docs = [
+    {
+      docId: 'A',
+      versionId: '1',
+      links: [],
+      updatedAt,
+      boolean: true,
+      array: [],
+      object: {},
+    },
+    {
+      docId: 'B',
+      versionId: '1',
+      links: [],
+      updatedAt,
+      boolean: false,
+      array: ['foo'],
+      object: { foo: 'bar' },
+    },
+    { docId: 'C', versionId: '1', links: [], updatedAt, array: [], object: {} },
+  ]
+
+  const extraColumns = `
+boolean INTEGER NOT NULL DEFAULT 0,
+array TEXT NOT NULL,
+object TEXT NOT NULL`
+
+  const { indexer, db, cleanup } = create({ extraColumns })
+
+  indexer.batch(docs)
+
+  const expected = [
+    {
+      docId: 'A',
+      versionId: '1',
+      links: '[]',
+      forks: '[]',
+      updatedAt,
+      boolean: 1,
+      array: '[]',
+      object: '{}',
+    },
+    {
+      docId: 'B',
+      versionId: '1',
+      links: '[]',
+      forks: '[]',
+      updatedAt,
+      boolean: 0,
+      array: '["foo"]',
+      object: '{"foo":"bar"}',
+    },
+    {
+      docId: 'C',
+      versionId: '1',
+      links: '[]',
+      forks: '[]',
+      updatedAt,
+      boolean: 0,
+      array: '[]',
+      object: '{}',
+    },
+  ]
+
+  t.deepEqual(db.prepare('SELECT * FROM docs').all(), expected)
+
+  cleanup()
+})

--- a/test/index-callback.js
+++ b/test/index-callback.js
@@ -3,14 +3,14 @@ import test from 'tape'
 import { create } from './utils.js'
 
 const docs = [
-  { id: 'A', seq: 1, version: '1', links: [] },
-  { id: 'A', seq: 2, version: '2', links: ['1'] },
-  { id: 'A', seq: 3, version: '3', links: ['1'] },
-  { id: 'A', seq: 4, version: '4', links: ['2', '3'] },
-  { id: 'A', seq: 5, version: '5', links: ['4'] },
-  { id: 'A', seq: 6, version: '6', links: ['4'] },
-  { id: 'A', seq: 7, version: '7', links: ['4'] },
-  { id: 'A', seq: 8, version: '8', links: ['5', '6'] },
+  { docId: 'A', seq: 1, versionId: '1', links: [], updatedAt: '' },
+  { docId: 'A', seq: 2, versionId: '2', links: ['1'], updatedAt: '' },
+  { docId: 'A', seq: 3, versionId: '3', links: ['1'], updatedAt: '' },
+  { docId: 'A', seq: 4, versionId: '4', links: ['2', '3'], updatedAt: '' },
+  { docId: 'A', seq: 5, versionId: '5', links: ['4'], updatedAt: '' },
+  { docId: 'A', seq: 6, versionId: '6', links: ['4'], updatedAt: '' },
+  { docId: 'A', seq: 7, versionId: '7', links: ['4'], updatedAt: '' },
+  { docId: 'A', seq: 8, versionId: '8', links: ['5', '6'], updatedAt: '' },
 ]
 
 test('onceWriteDoc called for each doc', async (t) => {
@@ -24,7 +24,7 @@ test('onceWriteDoc called for each doc', async (t) => {
 
   const { indexer, cleanup, clear } = create()
   for (const doc of docs) {
-    indexer.onceWriteDoc(doc.version, onWriteDoc)
+    indexer.onceWriteDoc(doc.versionId, onWriteDoc)
   }
   indexer.batch(docs)
   clear()

--- a/test/scenarios.js
+++ b/test/scenarios.js
@@ -3,44 +3,86 @@ import test from 'tape'
 import { create, permute } from './utils.js'
 
 const docs = [
-  { id: 'A', version: '1', links: [] },
-  { id: 'A', version: '2', links: ['1'] },
-  { id: 'A', version: '3', links: ['1'] },
-  { id: 'A', version: '4', links: ['2', '3'] },
-  { id: 'A', version: '5', links: ['4'] },
-  { id: 'A', version: '6', links: ['4'] },
-  { id: 'A', version: '7', links: ['4'] },
-  { id: 'A', version: '8', links: ['5', '6'] },
+  { docId: 'A', versionId: '1', links: [], updatedAt: '' },
+  { docId: 'A', versionId: '2', links: ['1'], updatedAt: '' },
+  { docId: 'A', versionId: '3', links: ['1'], updatedAt: '' },
+  { docId: 'A', versionId: '4', links: ['2', '3'], updatedAt: '' },
+  { docId: 'A', versionId: '5', links: ['4'], updatedAt: '' },
+  { docId: 'A', versionId: '6', links: ['4'], updatedAt: '' },
+  { docId: 'A', versionId: '7', links: ['4'], updatedAt: '' },
+  { docId: 'A', versionId: '8', links: ['5', '6'], updatedAt: '' },
 ]
 
 const scenarios = [
   {
     docs: docs.slice(0, 2),
-    expected: { id: 'A', version: '2', links: ['1'], forks: [] },
+    expected: {
+      docId: 'A',
+      versionId: '2',
+      links: ['1'],
+      forks: [],
+      updatedAt: '',
+    },
   },
   {
     docs: docs.slice(0, 3),
-    expected: { id: 'A', version: '3', links: ['1'], forks: ['2'] },
+    expected: {
+      docId: 'A',
+      versionId: '3',
+      links: ['1'],
+      forks: ['2'],
+      updatedAt: '',
+    },
   },
   {
     docs: docs.slice(0, 4),
-    expected: { id: 'A', version: '4', links: ['2', '3'], forks: [] },
+    expected: {
+      docId: 'A',
+      versionId: '4',
+      links: ['2', '3'],
+      forks: [],
+      updatedAt: '',
+    },
   },
   {
     docs: docs.slice(0, 5),
-    expected: { id: 'A', version: '5', links: ['4'], forks: [] },
+    expected: {
+      docId: 'A',
+      versionId: '5',
+      links: ['4'],
+      forks: [],
+      updatedAt: '',
+    },
   },
   {
     docs: docs.slice(0, 6),
-    expected: { id: 'A', version: '6', links: ['4'], forks: ['5'] },
+    expected: {
+      docId: 'A',
+      versionId: '6',
+      links: ['4'],
+      forks: ['5'],
+      updatedAt: '',
+    },
   },
   {
     docs: docs.slice(0, 7),
-    expected: { id: 'A', version: '7', links: ['4'], forks: ['5', '6'] },
+    expected: {
+      docId: 'A',
+      versionId: '7',
+      links: ['4'],
+      forks: ['5', '6'],
+      updatedAt: '',
+    },
   },
   {
     docs: docs.slice(0, 8),
-    expected: { id: 'A', version: '8', links: ['5', '6'], forks: ['7'] },
+    expected: {
+      docId: 'A',
+      versionId: '8',
+      links: ['5', '6'],
+      forks: ['7'],
+      updatedAt: '',
+    },
   },
 ]
 
@@ -53,11 +95,11 @@ test('Expected head for all permutations of order', async (t) => {
     // for (const permutation of [[docs[0], docs[3], docs[1], docs[2]]]) {
     for (const permutation of permute(docs)) {
       indexer.batch(permutation)
-      const head = api.getDoc(expected.id)
+      const head = api.getDoc(expected.docId)
       t.deepEqual(
         { ...head, forks: head?.forks.sort() },
         expected,
-        JSON.stringify(permutation.map((doc) => doc.version))
+        JSON.stringify(permutation.map((doc) => doc.versionId))
       )
       clear()
     }

--- a/test/timestamps.js
+++ b/test/timestamps.js
@@ -3,13 +3,16 @@ import test from 'tape'
 import { create } from './utils.js'
 
 test('If doc has timestamp, it is used to select winner', async (t) => {
+  const updated1 = new Date(1999, 0, 1).toISOString()
+  const updated2 = new Date(1999, 0, 2).toISOString()
+  const updated3 = new Date(1999, 0, 3).toISOString()
   const docs = [
-    { id: 'A', version: '1', links: [] },
-    { id: 'A', version: '2', links: ['1'], timestamp: Date.now() },
-    { id: 'A', version: '3', links: ['1'], timestamp: Date.now() - 1000 },
-    { id: 'B', version: '1', links: [] },
-    { id: 'B', version: '2', links: ['1'], timestamp: Date.now() - 1000 },
-    { id: 'B', version: '3', links: ['1'], timestamp: Date.now() },
+    { docId: 'A', versionId: '1', links: [], updatedAt: updated3 },
+    { docId: 'A', versionId: '2', links: ['1'], updatedAt: updated2 },
+    { docId: 'A', versionId: '3', links: ['1'], updatedAt: updated1 },
+    { docId: 'B', versionId: '1', links: [], updatedAt: updated3 },
+    { docId: 'B', versionId: '2', links: ['1'], updatedAt: updated1 },
+    { docId: 'B', versionId: '3', links: ['1'], updatedAt: updated2 },
   ]
 
   const { indexer, api, cleanup } = create({ extraColumns: 'timestamp NUMBER' })
@@ -18,31 +21,31 @@ test('If doc has timestamp, it is used to select winner', async (t) => {
 
   {
     const expected = {
-      id: 'A',
-      version: '2',
+      docId: 'A',
+      versionId: '2',
       links: ['1'],
       forks: ['3'],
     }
 
-    const head = api.getDoc(expected.id)
+    const head = api.getDoc(expected.docId)
     // @ts-ignore
     // eslint-disable-next-line no-unused-vars
-    const { timestamp, ...doc } = head
+    const { updatedAt, ...doc } = head
     t.deepEqual(doc, expected)
   }
 
   {
     const expected = {
-      id: 'B',
-      version: '3',
+      docId: 'B',
+      versionId: '3',
       links: ['1'],
       forks: ['2'],
     }
 
-    const head = api.getDoc(expected.id)
+    const head = api.getDoc(expected.docId)
     // @ts-ignore
     // eslint-disable-next-line no-unused-vars
-    const { timestamp, ...doc } = head
+    const { updatedAt, ...doc } = head
     t.deepEqual(doc, expected)
   }
 
@@ -50,26 +53,27 @@ test('If doc has timestamp, it is used to select winner', async (t) => {
 })
 
 test('If doc has no timestamp, version is used to select a deterministic winner', async (t) => {
+  const updatedAt = new Date().toISOString()
   const docs = [
-    { id: 'A', version: '1', links: [] },
-    { id: 'A', version: '2', links: ['1'] },
-    { id: 'A', version: '3', links: ['1'] },
+    { docId: 'A', versionId: '1', links: [], updatedAt },
+    { docId: 'A', versionId: '2', links: ['1'], updatedAt },
+    { docId: 'A', versionId: '3', links: ['1'], updatedAt },
   ]
 
   const { indexer, api, cleanup } = create()
 
   const expected = {
-    id: 'A',
-    version: '3',
+    docId: 'A',
+    versionId: '3',
     links: ['1'],
     forks: ['2'],
   }
 
   indexer.batch(docs)
-  const head = api.getDoc(expected.id)
+  const head = api.getDoc(expected.docId)
   // @ts-ignore
   // eslint-disable-next-line no-unused-vars
-  const { timestamp, ...doc } = head
+  const { updatedAt: _, ...doc } = head
   t.deepEqual(doc, expected)
 
   cleanup()

--- a/test/utils.js
+++ b/test/utils.js
@@ -45,7 +45,7 @@ export function create({ extraColumns = '' } = {}) {
     db.prepare(`DELETE FROM docs`).run()
     db.prepare(`DELETE FROM backlinks`).run()
   }
-  return { indexer, api, cleanup, clear }
+  return { indexer, api, cleanup, clear, db }
 }
 
 /**

--- a/test/utils.js
+++ b/test/utils.js
@@ -13,10 +13,11 @@ export function create({ extraColumns = '' } = {}) {
   db.prepare(
     `CREATE TABLE IF NOT EXISTS docs
     (
-      id TEXT PRIMARY KEY NOT NULL,
-      version TEXT NOT NULL,
+      docId TEXT PRIMARY KEY NOT NULL,
+      versionId TEXT NOT NULL,
       links TEXT NOT NULL,
-      forks TEXT NOT NULL
+      forks TEXT NOT NULL,
+      updatedAt TEXT NOT NULL
       ${extraColumns ? ', ' + extraColumns : ''}
     )
     WITHOUT ROWID`
@@ -24,7 +25,7 @@ export function create({ extraColumns = '' } = {}) {
 
   db.prepare(
     `CREATE TABLE IF NOT EXISTS backlinks
-    (version TEXT PRIMARY KEY NOT NULL)
+    (versionId TEXT PRIMARY KEY NOT NULL)
     WITHOUT ROWID`
   ).run()
 


### PR DESCRIPTION
SQLite can only store numbers (INTEGER or REAL) or strings (TEXT): https://www.sqlite.org/datatype3.html
Nullable fields are set to NULL if missing.

In Mapeo Core we [use Drizzle and custom fields](https://github.com/digidem/mapeo-core-next/blob/4da0146371a95dcae907db656ed3ec6c6ec16dbc/lib/schema/schema-to-drizzle.js#L204-L260) to map JSONSchema types to SQLite types and back. This module needs to do the same.

I initially attempted to do this by [integrating Drizzle](https://github.com/digidem/mapeo-sqlite-indexer/pull/10) into here, but that led to a 15x slowdown and issues with Drizzle. This PR instead does the conversion based on incoming data type and the column type read from the DB schema.

Because we use prepared statements, we need to pass a value for every property (even optional props), therefore the transform does:

- Missing props that are NOT NULL are set to the default value (`null` if no default set)
- Boolean props are set to `1` (true) or `0` (false) in an integer collumn
- Any array or object is JSON.stringify'd.

The indexer does not do reads, so it's only writes that matter.
