### PR TITLE
feat: add method to clear index

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,10 @@ Index an array of documents. Documents can be in any order. Documents must have 
 
 Set a listener for a doc at a specific version. Useful for performing an action based on completion of indexing of a document.
 
+### indexer.deleteAll()
+
+Delete all documents and backlinks. Useful if you want to reset the index.
+
 ### docs
 
 _Requires_\

--- a/index.js
+++ b/index.js
@@ -44,6 +44,7 @@ export class DbApi {
   #getBacklinkSql
   #writeBacklinkSql
   #updateForksSql
+  #deleteAll
   #docDefaults
   #tableInfo
 
@@ -87,6 +88,13 @@ export class DbApi {
       `INSERT OR IGNORE INTO ${backlinkTableName} (versionId)
       VALUES (?)`
     )
+
+    const deleteDocsSql = db.prepare(`DELETE FROM ${docTableName}`)
+    const deleteBacklinksSql = db.prepare(`DELETE FROM ${backlinkTableName}`)
+    this.#deleteAll = db.transaction(() => {
+      deleteDocsSql.run()
+      deleteBacklinksSql.run()
+    })
   }
   /**
    * @param {string} docId
@@ -140,6 +148,12 @@ export class DbApi {
    */
   writeBacklink(versionId) {
     this.#writeBacklinkSql.run(versionId)
+  }
+  /**
+   * @returns {void}
+   */
+  deleteAll() {
+    this.#deleteAll()
   }
 }
 
@@ -221,6 +235,10 @@ export default class SqliteIndexer {
   /** @param {string} versionId */
   isLinked(versionId) {
     return !!this.#dbApi.getBacklink(versionId)
+  }
+
+  deleteAll() {
+    this.#dbApi.deleteAll()
   }
 }
 

--- a/test/delete.js
+++ b/test/delete.js
@@ -1,0 +1,29 @@
+// @ts-check
+import test from 'tape'
+import { create } from './utils.js'
+
+test('deleting everything', (t) => {
+  const { indexer, db, cleanup } = create()
+
+  const docCount = db.prepare('SELECT COUNT(*) FROM docs').pluck()
+  const backlinkCount = db.prepare('SELECT COUNT(*) FROM backlinks').pluck()
+
+  const updatedAt = new Date().toISOString()
+  indexer.batch([
+    { docId: 'A', versionId: '1', links: [], updatedAt },
+    { docId: 'A', versionId: '2', links: ['1'], updatedAt },
+    { docId: 'B', versionId: '3', links: [], updatedAt },
+  ])
+
+  t.equal(docCount.get(), 2, 'Test setup expected 2 documents')
+  t.equal(backlinkCount.get(), 1, 'Test setup expected 1 backlink')
+
+  indexer.deleteAll()
+
+  t.equal(docCount.get(), 0, 'Expected all documents to be deleted')
+  t.equal(backlinkCount.get(), 0, 'Expected all backlinks to be deleted')
+
+  cleanup()
+
+  t.end()
+})


### PR DESCRIPTION
This adds `indexer.deleteAll()`, which deletes all rows from the docs table and the backlinks table.

Addresses #22.
