### PR TITLE
fix: don't document onceWriteDoc

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,10 +141,6 @@ The name of the table for storing backlinks (used internally for indexing).
 
 Index an array of documents. Documents can be in any order. Documents must have an `id` property, a `version` property that is unique, and a `links` property which is an array of version ids for the documents parent(s).
 
-### indexer.onceWriteDoc(version, listener)
-
-Set a listener for a doc at a specific version. Useful for performing an action based on completion of indexing of a document.
-
 ### indexer.deleteAll()
 
 Delete all documents and backlinks. Useful if you want to reset the index.


### PR DESCRIPTION
`indexer.onceWriteDoc` was removed in 8caaf6a9becf191aca8b9072a53b7671245496c7 (#21). This removes its mention in the readme.

`git grep -i onceWriteDoc` shows no remaining references to this method outside the changelog.
