### PR TITLE
chore!: drop Node 16 support

### DIFF
--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [16.17.1, 18.17.1, 20.x]
+        node-version: [18.17.1, 20.x]
 
     steps:
       - uses: actions/checkout@v2

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,8 +27,8 @@
         "typescript": "^5.1.6"
       },
       "engines": {
-        "node": ">=16.17.1",
-        "npm": ">=8.15.0"
+        "node": ">=18.17.1",
+        "npm": ">=9.6.7"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {

--- a/package.json
+++ b/package.json
@@ -18,8 +18,8 @@
   "author": "Digital Democracy",
   "license": "MIT",
   "engines": {
-    "node": ">=16.17.1",
-    "npm": ">=8.15.0"
+    "node": ">=18.17.1",
+    "npm": ">=9.6.7"
   },
   "dependencies": {
     "@types/better-sqlite3": "^7.6.4",


### PR DESCRIPTION
This removes Node 16 support, given that (1) it is deprecated (2) it [is no longer used in CoMapeo][0].

[0]: https://github.com/digidem/CoMapeo-mobile/pull/194